### PR TITLE
Wire up frontend to backend JSON data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { DataProvider } from './contexts/DataContext';
 import { SearchProvider } from './contexts/SearchContext';
 import Layout from './components/Layout';
 import Home from './pages/Home';
@@ -19,26 +20,28 @@ import SearchResults from './pages/SearchResults';
 function App() {
   return (
     <ThemeProvider>
-      <SearchProvider>
-        <Router>
-          <Layout>
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/calls" element={<Calls />} />
-              <Route path="/calls/:id" element={<CallDetail />} />
-              <Route path="/faq" element={<FAQ />} />
-              <Route path="/topics" element={<Topics />} />
-              <Route path="/topics/:slug" element={<TopicDetail />} />
-              <Route path="/decisions" element={<Decisions />} />
-              <Route path="/speakers" element={<Speakers />} />
-              <Route path="/speakers/:name" element={<SpeakerDetail />} />
-              <Route path="/marketing" element={<Marketing />} />
-              <Route path="/learn" element={<Learn />} />
-              <Route path="/search" element={<SearchResults />} />
-            </Routes>
-          </Layout>
-        </Router>
-      </SearchProvider>
+      <DataProvider>
+        <SearchProvider>
+          <Router>
+            <Layout>
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/calls" element={<Calls />} />
+                <Route path="/calls/:id" element={<CallDetail />} />
+                <Route path="/faq" element={<FAQ />} />
+                <Route path="/topics" element={<Topics />} />
+                <Route path="/topics/:slug" element={<TopicDetail />} />
+                <Route path="/decisions" element={<Decisions />} />
+                <Route path="/speakers" element={<Speakers />} />
+                <Route path="/speakers/:name" element={<SpeakerDetail />} />
+                <Route path="/marketing" element={<Marketing />} />
+                <Route path="/learn" element={<Learn />} />
+                <Route path="/search" element={<SearchResults />} />
+              </Routes>
+            </Layout>
+          </Router>
+        </SearchProvider>
+      </DataProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/CallCard.tsx
+++ b/src/components/CallCard.tsx
@@ -1,22 +1,32 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Calendar, Clock, Users, MessageSquare, FileText, GitBranch, Youtube, Headphones } from 'lucide-react';
-import { Call } from '../types';
+import { Calendar, Clock, Users, Youtube } from 'lucide-react';
+import type { CallSummary, CallMeta } from '../types';
 
 interface CallCardProps {
-  call: Call;
+  call: CallSummary | CallMeta;
 }
 
 export default function CallCard({ call }: CallCardProps) {
+  // Get YouTube URL - either from meta's media object or construct from ID
+  const youtubeUrl = 'media' in call && call.media?.youtube
+    ? call.media.youtube
+    : `https://youtube.com/watch?v=${call.id}`;
+
+  const speakersList = call.speakers.filter(Boolean).join(', ') || 'Community';
+
   return (
     <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6 hover:border-ergo-orange/50 transition-all duration-300 group">
       <div className="flex flex-col lg:flex-row gap-4">
         {/* Thumbnail */}
         <div className="lg:w-48 h-32 lg:h-28 bg-ergo-darker rounded overflow-hidden flex-shrink-0">
-          <img 
-            src={call.thumbnail} 
+          <img
+            src={call.thumbnail}
             alt={call.title}
             className="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity"
+            onError={(e) => {
+              (e.target as HTMLImageElement).src = `https://img.youtube.com/vi/${call.id}/mqdefault.jpg`;
+            }}
           />
         </div>
 
@@ -39,13 +49,9 @@ export default function CallCard({ call }: CallCardProps) {
             </span>
             <span className="flex items-center gap-1">
               <Users className="w-3 h-3" />
-              {call.speakers.join(', ')}
+              {speakersList}
             </span>
           </div>
-
-          <p className="text-sm text-ergo-light/80 mb-4 line-clamp-2">
-            {call.summary}
-          </p>
 
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-4 text-xs font-mono">
@@ -55,26 +61,15 @@ export default function CallCard({ call }: CallCardProps) {
             </div>
 
             <div className="flex items-center gap-2">
-              {call.media.youtube && (
-                <a 
-                  href={call.media.youtube} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="p-1.5 bg-ergo-darker rounded hover:bg-ergo-orange/20 transition-colors"
-                >
-                  <Youtube className="w-4 h-4" />
-                </a>
-              )}
-              {call.media.spotify && (
-                <a 
-                  href={call.media.spotify} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="p-1.5 bg-ergo-darker rounded hover:bg-ergo-orange/20 transition-colors"
-                >
-                  <Headphones className="w-4 h-4" />
-                </a>
-              )}
+              <a
+                href={youtubeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="p-1.5 bg-ergo-darker rounded hover:bg-ergo-orange/20 transition-colors"
+                title="Watch on YouTube"
+              >
+                <Youtube className="w-4 h-4" />
+              </a>
             </div>
           </div>
         </div>

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,0 +1,173 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import type {
+  Index,
+  IndexStats,
+  CallSummary,
+  CallMeta,
+  QAData,
+  DecisionsData,
+  Topic,
+  Speaker,
+  AggregatedDecision,
+  AggregatedQA
+} from '../types';
+import {
+  fetchIndex,
+  fetchSpeakers,
+  fetchTopics,
+  fetchCallMeta,
+  fetchCallSummary,
+  fetchCallTranscript,
+  fetchCallQA,
+  fetchCallDecisions,
+  fetchCallMarketing,
+  fetchAllQA,
+  fetchAllDecisions,
+  findCallById
+} from '../services/dataService';
+
+interface DataContextType {
+  // Core data
+  index: Index | null;
+  stats: IndexStats | null;
+  calls: CallSummary[];
+  speakers: Speaker[];
+  topics: Topic[];
+
+  // Loading states
+  isLoading: boolean;
+  isInitialized: boolean;
+  error: string | null;
+
+  // Aggregated data (lazy loaded)
+  allQA: AggregatedQA[] | null;
+  allDecisions: AggregatedDecision[] | null;
+  loadAllQA: () => Promise<AggregatedQA[]>;
+  loadAllDecisions: () => Promise<AggregatedDecision[]>;
+
+  // Call detail loaders
+  getCallById: (id: string) => Promise<{ call: CallMeta; filePrefix: string } | null>;
+  loadCallSummary: (filePrefix: string) => Promise<string>;
+  loadCallTranscript: (filePrefix: string) => Promise<string>;
+  loadCallQA: (filePrefix: string) => Promise<QAData>;
+  loadCallDecisions: (filePrefix: string) => Promise<DecisionsData>;
+  loadCallMarketing: (filePrefix: string) => Promise<string>;
+}
+
+const DataContext = createContext<DataContextType | undefined>(undefined);
+
+export function DataProvider({ children }: { children: React.ReactNode }) {
+  const [index, setIndex] = useState<Index | null>(null);
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [topics, setTopics] = useState<Topic[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [allQA, setAllQA] = useState<AggregatedQA[] | null>(null);
+  const [allDecisions, setAllDecisions] = useState<AggregatedDecision[] | null>(null);
+
+  // Initialize core data on mount
+  useEffect(() => {
+    async function init() {
+      try {
+        setIsLoading(true);
+        const [indexData, speakersData, topicsData] = await Promise.all([
+          fetchIndex(),
+          fetchSpeakers(),
+          fetchTopics()
+        ]);
+        setIndex(indexData);
+        setSpeakers(speakersData);
+        setTopics(topicsData);
+        setIsInitialized(true);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load data');
+        console.error('Failed to initialize data:', e);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    init();
+  }, []);
+
+  // Lazy load all Q&A
+  const loadAllQA = useCallback(async (): Promise<AggregatedQA[]> => {
+    if (allQA) return allQA;
+    const data = await fetchAllQA();
+    setAllQA(data);
+    return data;
+  }, [allQA]);
+
+  // Lazy load all decisions
+  const loadAllDecisions = useCallback(async (): Promise<AggregatedDecision[]> => {
+    if (allDecisions) return allDecisions;
+    const data = await fetchAllDecisions();
+    setAllDecisions(data);
+    return data;
+  }, [allDecisions]);
+
+  // Get call by ID
+  const getCallById = useCallback(async (id: string) => {
+    return findCallById(id);
+  }, []);
+
+  // Load call summary
+  const loadCallSummary = useCallback(async (filePrefix: string) => {
+    return fetchCallSummary(filePrefix);
+  }, []);
+
+  // Load call transcript
+  const loadCallTranscript = useCallback(async (filePrefix: string) => {
+    return fetchCallTranscript(filePrefix);
+  }, []);
+
+  // Load call Q&A
+  const loadCallQA = useCallback(async (filePrefix: string) => {
+    return fetchCallQA(filePrefix);
+  }, []);
+
+  // Load call decisions
+  const loadCallDecisions = useCallback(async (filePrefix: string) => {
+    return fetchCallDecisions(filePrefix);
+  }, []);
+
+  // Load call marketing
+  const loadCallMarketing = useCallback(async (filePrefix: string) => {
+    return fetchCallMarketing(filePrefix);
+  }, []);
+
+  const value: DataContextType = {
+    index,
+    stats: index?.stats || null,
+    calls: index?.calls || [],
+    speakers,
+    topics,
+    isLoading,
+    isInitialized,
+    error,
+    allQA,
+    allDecisions,
+    loadAllQA,
+    loadAllDecisions,
+    getCallById,
+    loadCallSummary,
+    loadCallTranscript,
+    loadCallQA,
+    loadCallDecisions,
+    loadCallMarketing,
+  };
+
+  return (
+    <DataContext.Provider value={value}>
+      {children}
+    </DataContext.Provider>
+  );
+}
+
+export function useData() {
+  const context = useContext(DataContext);
+  if (!context) {
+    throw new Error('useData must be used within a DataProvider');
+  }
+  return context;
+}

--- a/src/pages/CallDetail.tsx
+++ b/src/pages/CallDetail.tsx
@@ -1,41 +1,332 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { Calendar, Clock, Users, Youtube, Headphones, ExternalLink, Copy, ChevronRight } from 'lucide-react';
+import { Calendar, Clock, Users, Youtube, ExternalLink, Copy, ChevronRight, Loader2 } from 'lucide-react';
 import TabNavigation from '../components/TabNavigation';
 import TopicTag from '../components/TopicTag';
-import { mockCalls, mockQA, mockDecisions } from '../data/mockData';
+import { useData } from '../contexts/DataContext';
+import type { CallMeta, QAData, DecisionsData } from '../types';
 
 export default function CallDetail() {
   const { id } = useParams();
+  const { calls, getCallById, loadCallSummary, loadCallTranscript, loadCallQA, loadCallDecisions, loadCallMarketing } = useData();
+
   const [activeTab, setActiveTab] = useState('summary');
   const [copied, setCopied] = useState(false);
 
-  const call = mockCalls.find(c => c.id === id);
-  const callQA = mockQA.filter(qa => qa.call_id === id);
-  const callDecisions = mockDecisions.filter(d => d.call_id === id);
+  // Call metadata
+  const [callMeta, setCallMeta] = useState<CallMeta | null>(null);
+  const [filePrefix, setFilePrefix] = useState<string>('');
+  const [isLoadingMeta, setIsLoadingMeta] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  if (!call) {
+  // Tab content (lazy loaded)
+  const [summary, setSummary] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<string | null>(null);
+  const [qaData, setQAData] = useState<QAData | null>(null);
+  const [decisionsData, setDecisionsData] = useState<DecisionsData | null>(null);
+  const [marketing, setMarketing] = useState<string | null>(null);
+
+  // Loading states per tab
+  const [loadingTab, setLoadingTab] = useState<string | null>(null);
+
+  // Load call metadata
+  useEffect(() => {
+    if (!id) return;
+
+    async function loadCall() {
+      setIsLoadingMeta(true);
+      setError(null);
+      try {
+        const result = await getCallById(id);
+        if (result) {
+          setCallMeta(result.call);
+          setFilePrefix(result.filePrefix);
+        } else {
+          setError('Call not found');
+        }
+      } catch (e) {
+        setError('Failed to load call');
+      } finally {
+        setIsLoadingMeta(false);
+      }
+    }
+    loadCall();
+  }, [id, getCallById]);
+
+  // Load tab content when tab changes
+  useEffect(() => {
+    if (!filePrefix) return;
+
+    async function loadTabContent() {
+      setLoadingTab(activeTab);
+      try {
+        switch (activeTab) {
+          case 'summary':
+            if (!summary) {
+              const data = await loadCallSummary(filePrefix);
+              setSummary(data);
+            }
+            break;
+          case 'transcript':
+            if (!transcript) {
+              const data = await loadCallTranscript(filePrefix);
+              setTranscript(data);
+            }
+            break;
+          case 'qa':
+            if (!qaData) {
+              const data = await loadCallQA(filePrefix);
+              setQAData(data);
+            }
+            break;
+          case 'decisions':
+            if (!decisionsData) {
+              const data = await loadCallDecisions(filePrefix);
+              setDecisionsData(data);
+            }
+            break;
+          case 'marketing':
+            if (!marketing) {
+              const data = await loadCallMarketing(filePrefix);
+              setMarketing(data);
+            }
+            break;
+        }
+      } catch (e) {
+        console.error(`Failed to load ${activeTab}:`, e);
+      } finally {
+        setLoadingTab(null);
+      }
+    }
+    loadTabContent();
+  }, [activeTab, filePrefix, summary, transcript, qaData, decisionsData, marketing,
+      loadCallSummary, loadCallTranscript, loadCallQA, loadCallDecisions, loadCallMarketing]);
+
+  const handleCopy = () => {
+    if (!callMeta) return;
+    const citation = `${callMeta.title} - Ergo Community Call (${callMeta.date}). Available at: https://ergokb.org/calls/${callMeta.id}`;
+    navigator.clipboard.writeText(citation);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoadingMeta) {
     return (
-      <div className="container mx-auto px-4 py-16 text-center">
-        <h1 className="text-2xl font-mono text-ergo-orange">Call not found</h1>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="w-12 h-12 text-ergo-orange animate-spin mx-auto mb-4" />
+          <p className="font-mono text-ergo-muted">Loading call...</p>
+        </div>
       </div>
     );
   }
 
+  if (error || !callMeta) {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <h1 className="text-2xl font-mono text-ergo-orange mb-4">Call not found</h1>
+        <Link to="/calls" className="text-ergo-muted hover:text-ergo-orange font-mono">
+          Back to Calls
+        </Link>
+      </div>
+    );
+  }
+
+  const youtubeUrl = callMeta.media?.youtube || `https://youtube.com/watch?v=${callMeta.id}`;
+  const speakersList = callMeta.speakers.filter(Boolean);
+  const topicsList = callMeta.topics || [];
+
+  // Get related calls (other recent calls)
+  const relatedCalls = calls.filter(c => c.id !== id).slice(0, 3);
+
   const tabs = [
     { id: 'summary', label: 'Summary' },
-    { id: 'topics', label: 'Topics', count: call.stats.topics },
-    { id: 'qa', label: 'Q&A', count: callQA.length },
-    { id: 'decisions', label: 'Decisions', count: callDecisions.length },
+    { id: 'topics', label: 'Topics', count: topicsList.length },
+    { id: 'qa', label: 'Q&A', count: callMeta.stats.qa_pairs },
+    { id: 'decisions', label: 'Decisions', count: callMeta.stats.decisions + callMeta.stats.commitments },
     { id: 'transcript', label: 'Transcript' },
     { id: 'marketing', label: 'Marketing' },
   ];
 
-  const handleCopy = () => {
-    const citation = `${call.title} - Ergo Community Call (${call.date}). Available at: https://ergokb.org/calls/${call.id}`;
-    navigator.clipboard.writeText(citation);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const renderTabContent = () => {
+    if (loadingTab === activeTab) {
+      return (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-8 h-8 text-ergo-orange animate-spin" />
+        </div>
+      );
+    }
+
+    switch (activeTab) {
+      case 'summary':
+        return (
+          <div className="prose prose-invert max-w-none">
+            <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+              <h3 className="text-xl font-mono text-ergo-orange mb-4">Summary</h3>
+              {summary ? (
+                <div className="text-ergo-light/90 leading-relaxed whitespace-pre-wrap">
+                  {summary}
+                </div>
+              ) : (
+                <p className="text-ergo-muted">Loading summary...</p>
+              )}
+            </div>
+          </div>
+        );
+
+      case 'topics':
+        return (
+          <div className="space-y-4">
+            {topicsList.length === 0 ? (
+              <p className="text-ergo-muted font-mono text-center py-8">No topics found</p>
+            ) : (
+              topicsList.map((topic, index) => (
+                <div key={topic} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-4 hover:border-ergo-orange/50 transition-all">
+                  <div className="flex items-start justify-between mb-2">
+                    <div className="flex items-center gap-3">
+                      <h4 className="font-mono font-semibold text-ergo-orange">{topic}</h4>
+                    </div>
+                    <Link
+                      to={`/topics/${topic.toLowerCase().replace(/\s+/g, '-')}`}
+                      className="text-sm font-mono text-ergo-muted hover:text-ergo-orange"
+                    >
+                      View topic
+                    </Link>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        );
+
+      case 'qa':
+        return (
+          <div className="space-y-6">
+            {qaData?.qa_pairs && qaData.qa_pairs.length > 0 ? (
+              qaData.qa_pairs.map((qa, idx) => (
+                <div key={qa.qa_id || idx} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+                  <div className="mb-3">
+                    <span className="text-sm font-mono text-term-cyan">Q:</span>
+                    <p className="mt-1 font-medium">{qa.question}</p>
+                  </div>
+                  <div className="mb-3">
+                    <span className="text-sm font-mono text-term-green">A:</span>
+                    <p className="mt-1 text-ergo-light/90">{qa.answer}</p>
+                  </div>
+                  <div className="flex items-center justify-between text-xs font-mono text-ergo-muted">
+                    <span>{qa.responder} {qa.timestamp && `@ ${qa.timestamp}`}</span>
+                    <span className="px-2 py-1 bg-ergo-darker rounded">
+                      [{qa.category}]
+                    </span>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <p className="text-ergo-muted font-mono text-center py-8">No Q&A pairs found</p>
+            )}
+          </div>
+        );
+
+      case 'decisions':
+        return (
+          <div className="space-y-4">
+            {/* Decisions */}
+            {decisionsData?.decisions?.map((decision) => (
+              <div key={`decision-${decision.id}`} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+                <div className="flex items-start justify-between mb-3">
+                  <span className="text-xs font-mono px-2 py-1 rounded bg-blue-500/20 text-blue-400">
+                    {decision.significance === 'major' ? 'MAJOR ' : ''}DECISION
+                  </span>
+                  <span className="text-xs font-mono text-ergo-muted">{decision.timestamp}</span>
+                </div>
+                <h3 className="font-mono font-semibold text-ergo-orange mb-2">{decision.decision}</h3>
+                {decision.context && (
+                  <p className="text-sm text-ergo-muted mb-2">Context: {decision.context}</p>
+                )}
+                {decision.quote && (
+                  <blockquote className="text-sm text-ergo-light/80 border-l-2 border-ergo-orange/50 pl-3 mb-2 italic">
+                    "{decision.quote}"
+                  </blockquote>
+                )}
+                <div className="text-xs font-mono text-ergo-muted">
+                  {decision.speaker} | Topic: {decision.topic}
+                </div>
+              </div>
+            ))}
+
+            {/* Commitments */}
+            {decisionsData?.commitments?.map((commitment) => (
+              <div key={`commitment-${commitment.id}`} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+                <div className="flex items-start justify-between mb-3">
+                  <span className="text-xs font-mono px-2 py-1 rounded bg-green-500/20 text-green-400">
+                    COMMITMENT
+                  </span>
+                  <span className="text-xs font-mono text-ergo-muted">{commitment.timeline}</span>
+                </div>
+                <h3 className="font-mono font-semibold text-ergo-orange mb-2">{commitment.commitment}</h3>
+                <div className="text-xs font-mono text-ergo-muted">
+                  Owner: {commitment.owner} | Topic: {commitment.topic}
+                </div>
+              </div>
+            ))}
+
+            {/* Open Questions */}
+            {decisionsData?.open_questions?.map((question) => (
+              <div key={`question-${question.id}`} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+                <div className="flex items-start justify-between mb-3">
+                  <span className="text-xs font-mono px-2 py-1 rounded bg-yellow-500/20 text-yellow-400">
+                    OPEN QUESTION
+                  </span>
+                </div>
+                <h3 className="font-mono font-semibold text-ergo-orange mb-2">{question.question}</h3>
+                <p className="text-sm text-ergo-muted mb-2">{question.context}</p>
+                <div className="text-xs font-mono text-ergo-muted">
+                  Raised by: {question.raised_by} | Topic: {question.topic}
+                </div>
+              </div>
+            ))}
+
+            {(!decisionsData?.decisions?.length && !decisionsData?.commitments?.length && !decisionsData?.open_questions?.length) && (
+              <p className="text-ergo-muted font-mono text-center py-8">No decisions or commitments found</p>
+            )}
+          </div>
+        );
+
+      case 'transcript':
+        return (
+          <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+            <div className="mb-4 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded">
+              <p className="text-sm font-mono text-yellow-400">
+                Full transcript available. Click timestamps to jump to video.
+              </p>
+            </div>
+            {transcript ? (
+              <pre className="font-mono text-sm whitespace-pre-wrap text-ergo-light/90 max-h-[600px] overflow-y-auto">
+                {transcript}
+              </pre>
+            ) : (
+              <p className="text-ergo-muted font-mono">Loading transcript...</p>
+            )}
+          </div>
+        );
+
+      case 'marketing':
+        return (
+          <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+            <h3 className="text-lg font-mono text-ergo-orange mb-4">Marketing Content</h3>
+            {marketing ? (
+              <div className="prose prose-invert max-w-none whitespace-pre-wrap text-ergo-light/90">
+                {marketing}
+              </div>
+            ) : (
+              <p className="text-ergo-muted font-mono">Loading marketing content...</p>
+            )}
+          </div>
+        );
+
+      default:
+        return null;
+    }
   };
 
   return (
@@ -44,252 +335,66 @@ export default function CallDetail() {
       <div className="flex items-center gap-2 text-sm font-mono text-ergo-muted mb-6">
         <Link to="/calls" className="hover:text-ergo-orange">Calls</Link>
         <ChevronRight className="w-4 h-4" />
-        <span className="text-ergo-light">{call.title}</span>
+        <span className="text-ergo-light line-clamp-1">{callMeta.title}</span>
       </div>
 
       {/* Header */}
       <header className="mb-8">
         <h1 className="text-3xl font-bold font-mono text-gradient mb-4">
-          {call.title}
+          {callMeta.title}
         </h1>
 
         <div className="flex flex-wrap items-center gap-4 text-sm font-mono text-ergo-muted mb-4">
           <span className="flex items-center gap-1">
             <Calendar className="w-4 h-4" />
-            {call.date}
+            {callMeta.date}
           </span>
           <span className="flex items-center gap-1">
             <Clock className="w-4 h-4" />
-            {call.duration_minutes} minutes
+            {callMeta.duration_minutes} minutes
           </span>
           <span className="flex items-center gap-1">
             <Users className="w-4 h-4" />
-            {call.speakers.length} speakers
+            {speakersList.length || 0} speakers
           </span>
         </div>
 
         {/* Media Links */}
         <div className="flex flex-wrap gap-3 mb-6">
-          {call.media.youtube && (
-            <a
-              href={call.media.youtube}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 px-4 py-2 bg-red-500/20 hover:bg-red-500/30 border border-red-500/50 rounded font-mono text-sm transition-colors"
-            >
-              <Youtube className="w-4 h-4" />
-              YouTube
-              <ExternalLink className="w-3 h-3" />
-            </a>
-          )}
-          {call.media.spotify && (
-            <a
-              href={call.media.spotify}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 px-4 py-2 bg-green-500/20 hover:bg-green-500/30 border border-green-500/50 rounded font-mono text-sm transition-colors"
-            >
-              <Headphones className="w-4 h-4" />
-              Spotify
-              <ExternalLink className="w-3 h-3" />
-            </a>
-          )}
+          <a
+            href={youtubeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-4 py-2 bg-red-500/20 hover:bg-red-500/30 border border-red-500/50 rounded font-mono text-sm transition-colors"
+          >
+            <Youtube className="w-4 h-4" />
+            YouTube
+            <ExternalLink className="w-3 h-3" />
+          </a>
         </div>
 
         {/* Speakers */}
-        <div className="flex flex-wrap gap-2">
-          {call.speakers.map(speaker => (
-            <Link
-              key={speaker}
-              to={`/speakers/${speaker}`}
-              className="px-3 py-1 bg-ergo-dark border border-ergo-orange/30 rounded font-mono text-sm hover:border-ergo-orange transition-colors"
-            >
-              🎤 {speaker}
-            </Link>
-          ))}
-        </div>
+        {speakersList.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {speakersList.map(speaker => (
+              <Link
+                key={speaker}
+                to={`/speakers/${encodeURIComponent(speaker)}`}
+                className="px-3 py-1 bg-ergo-dark border border-ergo-orange/30 rounded font-mono text-sm hover:border-ergo-orange transition-colors"
+              >
+                {speaker}
+              </Link>
+            ))}
+          </div>
+        )}
       </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Main Content */}
         <div className="lg:col-span-2">
           <TabNavigation tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
-
           <div className="mt-6">
-            {/* Summary Tab */}
-            {activeTab === 'summary' && (
-              <div className="prose prose-invert max-w-none">
-                <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-                  <h3 className="text-xl font-mono text-ergo-orange mb-4">Executive Summary</h3>
-                  <p className="text-ergo-light/90 leading-relaxed">{call.summary}</p>
-                  
-                  <div className="mt-6">
-                    <h4 className="text-lg font-mono text-ergo-orange mb-3">Key Announcements</h4>
-                    <ul className="space-y-2 text-ergo-light/80">
-                      <li className="flex items-start gap-2">
-                        <span className="text-ergo-green mt-1">▸</span>
-                        <span>AI coding tools integration with ErgoScript demonstrated</span>
-                      </li>
-                      <li className="flex items-start gap-2">
-                        <span className="text-ergo-green mt-1">▸</span>
-                        <span>New optimization techniques for contract deployment</span>
-                      </li>
-                      <li className="flex items-start gap-2">
-                        <span className="text-ergo-green mt-1">▸</span>
-                        <span>Community feedback on development priorities collected</span>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Topics Tab */}
-            {activeTab === 'topics' && (
-              <div className="space-y-4">
-                {call.topics.map((topic, index) => (
-                  <div key={topic} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-4 hover:border-ergo-orange/50 transition-all">
-                    <div className="flex items-start justify-between mb-2">
-                      <div className="flex items-center gap-3">
-                        <span className="text-term-amber font-mono">▶ {(index * 12 + 5).toString().padStart(2, '0')}:23</span>
-                        <h4 className="font-mono font-semibold text-ergo-orange">{topic}</h4>
-                      </div>
-                      <a
-                        href={`${call.media.youtube}&t=${index * 12 + 5}m23s`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm font-mono text-ergo-muted hover:text-ergo-orange"
-                      >
-                        Jump to video →
-                      </a>
-                    </div>
-                    <p className="text-sm text-ergo-light/80">
-                      Discussion about {topic} implementation and best practices in the Ergo ecosystem.
-                    </p>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Q&A Tab */}
-            {activeTab === 'qa' && (
-              <div className="space-y-6">
-                {callQA.map(qa => (
-                  <div key={qa.id} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-                    <div className="mb-3">
-                      <span className="text-sm font-mono text-term-cyan">Q:</span>
-                      <p className="mt-1 font-medium">{qa.question}</p>
-                    </div>
-                    <div className="mb-3">
-                      <span className="text-sm font-mono text-term-green">A:</span>
-                      <p className="mt-1 text-ergo-light/90">{qa.answer}</p>
-                    </div>
-                    <div className="flex items-center justify-between text-xs font-mono text-ergo-muted">
-                      <span>🎤 {qa.responder} • {qa.timestamp}</span>
-                      <span className="px-2 py-1 bg-ergo-darker rounded">
-                        [{qa.category}]
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Decisions Tab */}
-            {activeTab === 'decisions' && (
-              <div className="space-y-4">
-                {callDecisions.map(decision => (
-                  <div key={decision.id} className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-                    <div className="flex items-start justify-between mb-3">
-                      <span className={`
-                        text-xs font-mono px-2 py-1 rounded
-                        ${decision.type === 'decision' ? 'bg-blue-500/20 text-blue-400' : ''}
-                        ${decision.type === 'commitment' ? 'bg-green-500/20 text-green-400' : ''}
-                        ${decision.type === 'open_question' ? 'bg-yellow-500/20 text-yellow-400' : ''}
-                      `}>
-                        {decision.significance === 'major' ? '🔹 MAJOR ' : ''}{decision.type.toUpperCase()}
-                      </span>
-                      <span className="text-xs font-mono text-ergo-muted">{decision.date}</span>
-                    </div>
-                    
-                    <h3 className="font-mono font-semibold text-ergo-orange mb-2">
-                      {decision.title}
-                    </h3>
-                    
-                    {decision.context && (
-                      <p className="text-sm text-ergo-muted mb-2">
-                        Context: {decision.context}
-                      </p>
-                    )}
-                    
-                    <p className="text-sm text-ergo-light/90 mb-3">
-                      {decision.content}
-                    </p>
-                    
-                    <div className="text-xs font-mono text-ergo-muted">
-                      🎤 {decision.speaker} • Topic: {decision.topic}
-                      {decision.owner && ` • Owner: ${decision.owner}`}
-                      {decision.timeline && ` • Timeline: ${decision.timeline}`}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Transcript Tab */}
-            {activeTab === 'transcript' && (
-              <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-                <div className="mb-4 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded">
-                  <p className="text-sm font-mono text-yellow-400">
-                    Full transcript available. Click timestamps to jump to video.
-                  </p>
-                </div>
-                <div className="space-y-4 font-mono text-sm">
-                  <div>
-                    <span className="text-term-amber">[00:00]</span>
-                    <span className="text-ergo-orange ml-2">qx:</span>
-                    <span className="ml-2">Welcome everyone to today's Ergo Community Chat...</span>
-                  </div>
-                  <div>
-                    <span className="text-term-amber">[00:15]</span>
-                    <span className="text-ergo-orange ml-2">kushti:</span>
-                    <span className="ml-2">Thanks for having me. Today we'll discuss AI coding...</span>
-                  </div>
-                  <div>
-                    <span className="text-term-amber">[01:23]</span>
-                    <span className="text-ergo-orange ml-2">HQ:</span>
-                    <span className="ml-2">Let's start with the recent developments in ErgoScript...</span>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Marketing Tab */}
-            {activeTab === 'marketing' && (
-              <div className="space-y-6">
-                <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-                  <h3 className="text-lg font-mono text-ergo-orange mb-4">Twitter Thread</h3>
-                  <div className="space-y-3 font-mono text-sm">
-                    <p>🧵 1/ Just wrapped up an amazing Ergo Community Chat on AI Coding Revolution!</p>
-                    <p>2/ @kushti_ru demonstrated how GPT-4 and Copilot can accelerate ErgoScript development</p>
-                    <p>3/ Key takeaway: AI tools can help with boilerplate but always verify contract logic</p>
-                  </div>
-                  <button className="mt-4 px-4 py-2 bg-ergo-orange/20 hover:bg-ergo-orange/30 border border-ergo-orange/50 rounded font-mono text-sm transition-colors">
-                    Copy Thread
-                  </button>
-                </div>
-
-                <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-                  <h3 className="text-lg font-mono text-ergo-orange mb-4">Quotable Moments</h3>
-                  <div className="space-y-3">
-                    <blockquote className="border-l-4 border-ergo-orange pl-4">
-                      <p className="italic">"AI is not replacing developers, it's amplifying their capabilities"</p>
-                      <cite className="text-sm font-mono text-ergo-muted">- kushti</cite>
-                    </blockquote>
-                  </div>
-                </div>
-              </div>
-            )}
+            {renderTabContent()}
           </div>
         </div>
 
@@ -297,14 +402,16 @@ export default function CallDetail() {
         <aside className="lg:col-span-1">
           <div className="sticky top-24 space-y-6">
             {/* Topics */}
-            <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-              <h3 className="font-mono font-semibold text-ergo-orange mb-4">Topics</h3>
-              <div className="flex flex-wrap gap-2">
-                {call.topics.map(topic => (
-                  <TopicTag key={topic} topic={topic} />
-                ))}
+            {topicsList.length > 0 && (
+              <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+                <h3 className="font-mono font-semibold text-ergo-orange mb-4">Topics</h3>
+                <div className="flex flex-wrap gap-2">
+                  {topicsList.map(topic => (
+                    <TopicTag key={topic} topic={topic} />
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
 
             {/* Cite This Call */}
             <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
@@ -319,21 +426,23 @@ export default function CallDetail() {
             </div>
 
             {/* Related Calls */}
-            <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
-              <h3 className="font-mono font-semibold text-ergo-orange mb-4">Related Calls</h3>
-              <div className="space-y-3">
-                {mockCalls.slice(1, 4).map(relatedCall => (
-                  <Link
-                    key={relatedCall.id}
-                    to={`/calls/${relatedCall.id}`}
-                    className="block text-sm hover:text-ergo-orange transition-colors"
-                  >
-                    <p className="font-mono line-clamp-2">{relatedCall.title}</p>
-                    <p className="text-xs text-ergo-muted mt-1">{relatedCall.date}</p>
-                  </Link>
-                ))}
+            {relatedCalls.length > 0 && (
+              <div className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6">
+                <h3 className="font-mono font-semibold text-ergo-orange mb-4">Related Calls</h3>
+                <div className="space-y-3">
+                  {relatedCalls.map(relatedCall => (
+                    <Link
+                      key={relatedCall.id}
+                      to={`/calls/${relatedCall.id}`}
+                      className="block text-sm hover:text-ergo-orange transition-colors"
+                    >
+                      <p className="font-mono line-clamp-2">{relatedCall.title}</p>
+                      <p className="text-xs text-ergo-muted mt-1">{relatedCall.date}</p>
+                    </Link>
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </aside>
       </div>

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -1,23 +1,24 @@
 import React, { useState } from 'react';
-import { Calendar, Filter, ChevronDown } from 'lucide-react';
+import { Filter, Loader2 } from 'lucide-react';
 import CallCard from '../components/CallCard';
-import { mockCalls } from '../data/mockData';
+import { useData } from '../contexts/DataContext';
 
 export default function Calls() {
+  const { calls, isLoading } = useData();
   const [filterType, setFilterType] = useState<string>('all');
   const [sortBy, setSortBy] = useState<string>('newest');
   const [selectedSpeakers, setSelectedSpeakers] = useState<string[]>([]);
   const [showFilters, setShowFilters] = useState(false);
 
   const allSpeakers = Array.from(
-    new Set(mockCalls.flatMap(call => call.speakers))
-  ).sort();
+    new Set(calls.flatMap(call => call.speakers))
+  ).filter(Boolean).sort();
 
-  const filteredCalls = mockCalls
+  const filteredCalls = calls
     .filter(call => {
       if (filterType !== 'all' && call.type !== filterType) return false;
       if (selectedSpeakers.length > 0) {
-        const hasSelectedSpeaker = call.speakers.some(speaker => 
+        const hasSelectedSpeaker = call.speakers.some(speaker =>
           selectedSpeakers.includes(speaker)
         );
         if (!hasSelectedSpeaker) return false;
@@ -37,6 +38,17 @@ export default function Calls() {
       }
     });
 
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="w-12 h-12 text-ergo-orange animate-spin mx-auto mb-4" />
+          <p className="font-mono text-ergo-muted">Loading calls...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       {/* Header */}
@@ -45,7 +57,7 @@ export default function Calls() {
           Calls Archive
         </h1>
         <p className="text-ergo-muted font-mono">
-          Browse {mockCalls.length} indexed community calls
+          Browse {calls.length} indexed community calls
         </p>
       </div>
 
@@ -144,7 +156,7 @@ export default function Calls() {
           {/* Results Count */}
           <div className="mb-6">
             <p className="font-mono text-sm text-ergo-muted">
-              Showing {filteredCalls.length} of {mockCalls.length} calls
+              Showing {filteredCalls.length} of {calls.length} calls
             </p>
           </div>
 
@@ -155,12 +167,9 @@ export default function Calls() {
             ))}
           </div>
 
-          {/* Load More */}
-          {filteredCalls.length > 0 && (
-            <div className="mt-8 text-center">
-              <button className="px-6 py-3 bg-ergo-dark border border-ergo-orange/30 rounded font-mono text-sm hover:bg-ergo-orange/10 hover:border-ergo-orange transition-all">
-                Load More Calls
-              </button>
+          {filteredCalls.length === 0 && (
+            <div className="text-center py-12">
+              <p className="font-mono text-ergo-muted">No calls match your filters.</p>
             </div>
           )}
         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ArrowRight, TrendingUp, Activity } from 'lucide-react';
+import { ArrowRight, TrendingUp, Activity, Loader2 } from 'lucide-react';
 import SearchBar from '../components/SearchBar';
 import CallCard from '../components/CallCard';
 import StatCard from '../components/StatCard';
 import TopicTag from '../components/TopicTag';
-import { mockCalls, mockDecisions, mockTopics, mockStats } from '../data/mockData';
+import { useData } from '../contexts/DataContext';
 
 export default function Home() {
+  const { stats, calls, topics, isLoading, isInitialized, loadAllDecisions, allDecisions } = useData();
   const [typedText, setTypedText] = useState('');
+  const [decisionsLoading, setDecisionsLoading] = useState(false);
   const fullText = 'The institutional memory of Ergo';
 
   useEffect(() => {
@@ -24,11 +26,34 @@ export default function Home() {
     return () => clearInterval(timer);
   }, []);
 
+  // Load decisions for the recent decisions section
+  useEffect(() => {
+    if (isInitialized && !allDecisions) {
+      setDecisionsLoading(true);
+      loadAllDecisions().finally(() => setDecisionsLoading(false));
+    }
+  }, [isInitialized, allDecisions, loadAllDecisions]);
+
+  const recentCalls = calls.slice(0, 3);
+  const recentDecisions = allDecisions?.slice(0, 3) || [];
+  const trendingTopics = [...topics].sort((a, b) => b.mention_count - a.mention_count).slice(0, 10);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="w-12 h-12 text-ergo-orange animate-spin mx-auto mb-4" />
+          <p className="font-mono text-ergo-muted">Loading knowledge base...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative">
       {/* Grid Background */}
       <div className="absolute inset-0 grid-bg opacity-5"></div>
-      
+
       {/* Scan Line Effect */}
       <div className="scan-line"></div>
 
@@ -47,11 +72,11 @@ export default function Home() {
         {/* Stats Dashboard */}
         <div className="bg-ergo-dark/80 backdrop-blur border border-ergo-orange/30 rounded-lg p-6 mb-12 glow-orange">
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <StatCard label="CALLS INDEXED" value={mockStats.total_calls} />
-            <StatCard label="Q&A PAIRS" value={mockStats.total_qa.toLocaleString()} />
-            <StatCard label="DECISIONS TRACKED" value={mockStats.total_decisions} />
-            <StatCard label="SPEAKERS" value={mockStats.total_speakers} />
-            <StatCard label="HOURS OF CONTENT" value={`${mockStats.total_hours}+`} />
+            <StatCard label="CALLS INDEXED" value={stats?.total_calls || 0} />
+            <StatCard label="Q&A PAIRS" value={(stats?.total_qa || 0).toLocaleString()} />
+            <StatCard label="DECISIONS TRACKED" value={stats?.total_decisions || 0} />
+            <StatCard label="SPEAKERS" value={stats?.total_speakers || 0} />
+            <StatCard label="HOURS OF CONTENT" value={`${stats?.total_hours || 0}+`} />
             <StatCard label="LAST SYNC" value="LIVE" />
           </div>
         </div>
@@ -66,8 +91,8 @@ export default function Home() {
           <h2 className="text-2xl font-bold font-mono text-ergo-orange">
             Recent Calls
           </h2>
-          <Link 
-            to="/calls" 
+          <Link
+            to="/calls"
             className="flex items-center gap-2 text-sm font-mono text-ergo-muted hover:text-ergo-orange transition-colors"
           >
             View all <ArrowRight className="w-4 h-4" />
@@ -75,7 +100,7 @@ export default function Home() {
         </div>
 
         <div className="space-y-6">
-          {mockCalls.slice(0, 3).map(call => (
+          {recentCalls.map(call => (
             <CallCard key={call.id} call={call} />
           ))}
         </div>
@@ -87,54 +112,60 @@ export default function Home() {
           <h2 className="text-2xl font-bold font-mono text-ergo-orange">
             Recent Decisions
           </h2>
-          <Link 
-            to="/decisions" 
+          <Link
+            to="/decisions"
             className="flex items-center gap-2 text-sm font-mono text-ergo-muted hover:text-ergo-orange transition-colors"
           >
             View all <ArrowRight className="w-4 h-4" />
           </Link>
         </div>
 
-        <div className="grid gap-4">
-          {mockDecisions.slice(0, 3).map(decision => (
-            <div 
-              key={decision.id}
-              className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6 hover:border-ergo-orange/50 transition-all"
-            >
-              <div className="flex items-start justify-between mb-3">
-                <span className={`
-                  text-xs font-mono px-2 py-1 rounded
-                  ${decision.type === 'decision' ? 'bg-blue-500/20 text-blue-400' : ''}
-                  ${decision.type === 'commitment' ? 'bg-green-500/20 text-green-400' : ''}
-                  ${decision.type === 'open_question' ? 'bg-yellow-500/20 text-yellow-400' : ''}
-                `}>
-                  {decision.type.toUpperCase()}
-                </span>
-                <span className="text-xs font-mono text-ergo-muted">{decision.date}</span>
+        {decisionsLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="w-6 h-6 text-ergo-orange animate-spin" />
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {recentDecisions.map(decision => (
+              <div
+                key={decision.id}
+                className="bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6 hover:border-ergo-orange/50 transition-all"
+              >
+                <div className="flex items-start justify-between mb-3">
+                  <span className={`
+                    text-xs font-mono px-2 py-1 rounded
+                    ${decision.type === 'decision' ? 'bg-blue-500/20 text-blue-400' : ''}
+                    ${decision.type === 'commitment' ? 'bg-green-500/20 text-green-400' : ''}
+                    ${decision.type === 'open_question' ? 'bg-yellow-500/20 text-yellow-400' : ''}
+                  `}>
+                    {decision.type.toUpperCase().replace('_', ' ')}
+                  </span>
+                  <span className="text-xs font-mono text-ergo-muted">{decision.date}</span>
+                </div>
+
+                <h3 className="font-mono text-lg font-semibold text-ergo-orange mb-2">
+                  {decision.title}
+                </h3>
+
+                <p className="text-sm text-ergo-light/80 mb-3 line-clamp-2">
+                  {decision.content}
+                </p>
+
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-mono text-ergo-muted">
+                    {decision.speaker} | Topic: {decision.topic}
+                  </span>
+                  <Link
+                    to={`/calls/${decision.call_id}`}
+                    className="text-xs font-mono text-ergo-orange hover:text-orange-400"
+                  >
+                    View source
+                  </Link>
+                </div>
               </div>
-              
-              <h3 className="font-mono text-lg font-semibold text-ergo-orange mb-2">
-                {decision.title}
-              </h3>
-              
-              <p className="text-sm text-ergo-light/80 mb-3">
-                {decision.content}
-              </p>
-              
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-mono text-ergo-muted">
-                  🎤 {decision.speaker} • Topic: {decision.topic}
-                </span>
-                <Link 
-                  to={`/calls/${decision.call_id}`}
-                  className="text-xs font-mono text-ergo-orange hover:text-orange-400"
-                >
-                  View source →
-                </Link>
-              </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </section>
 
       {/* Trending Topics */}
@@ -144,8 +175,8 @@ export default function Home() {
             <TrendingUp className="w-6 h-6" />
             Trending Topics
           </h2>
-          <Link 
-            to="/topics" 
+          <Link
+            to="/topics"
             className="flex items-center gap-2 text-sm font-mono text-ergo-muted hover:text-ergo-orange transition-colors"
           >
             View all <ArrowRight className="w-4 h-4" />
@@ -153,10 +184,10 @@ export default function Home() {
         </div>
 
         <div className="flex flex-wrap gap-3">
-          {mockTopics.map(topic => (
-            <TopicTag 
-              key={topic.slug} 
-              topic={topic.name} 
+          {trendingTopics.map(topic => (
+            <TopicTag
+              key={topic.slug}
+              topic={topic.name}
               count={topic.mention_count}
               size="md"
             />
@@ -175,26 +206,34 @@ export default function Home() {
 
         <div className="bg-ergo-dark/50 border border-ergo-orange/20 rounded-lg p-6 font-mono text-sm">
           <div className="space-y-3">
-            <div className="flex items-center gap-3">
-              <span className="text-term-green">●</span>
-              <span className="text-ergo-muted">2 hours ago</span>
-              <span>New call indexed: "Ergo Community Chat - AI Coding Revolution"</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-term-amber">●</span>
-              <span className="text-ergo-muted">5 hours ago</span>
-              <span>12 new Q&A pairs added from recent AMA</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-term-cyan">●</span>
-              <span className="text-ergo-muted">1 day ago</span>
-              <span>Major decision: Rosen Bridge V2 architecture approved</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-term-green">●</span>
-              <span className="text-ergo-muted">2 days ago</span>
-              <span>Topic "concentrated-liquidity" trending (+15 mentions)</span>
-            </div>
+            {recentCalls[0] && (
+              <div className="flex items-center gap-3">
+                <span className="text-term-green">●</span>
+                <span className="text-ergo-muted">{new Date(recentCalls[0].date).toLocaleDateString()}</span>
+                <span>New call indexed: "{recentCalls[0].title}"</span>
+              </div>
+            )}
+            {stats && (
+              <div className="flex items-center gap-3">
+                <span className="text-term-amber">●</span>
+                <span className="text-ergo-muted">Total</span>
+                <span>{stats.total_qa} Q&A pairs across {stats.total_calls} calls</span>
+              </div>
+            )}
+            {trendingTopics[0] && (
+              <div className="flex items-center gap-3">
+                <span className="text-term-cyan">●</span>
+                <span className="text-ergo-muted">Trending</span>
+                <span>Topic "{trendingTopics[0].name}" ({trendingTopics[0].mention_count} mentions)</span>
+              </div>
+            )}
+            {stats && (
+              <div className="flex items-center gap-3">
+                <span className="text-term-green">●</span>
+                <span className="text-ergo-muted">Archive</span>
+                <span>{stats.total_hours}+ hours of community knowledge indexed</span>
+              </div>
+            )}
           </div>
         </div>
       </section>

--- a/src/pages/Speakers.tsx
+++ b/src/pages/Speakers.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { User, Mic, Gavel, Hash, Quote, Search, Grid, List } from 'lucide-react';
-import { mockSpeakers } from '../data/mockData';
+import { User, Mic, Gavel, Hash, Quote, Search, Grid, List, Loader2 } from 'lucide-react';
+import { useData } from '../contexts/DataContext';
 
 export default function Speakers() {
+  const { speakers, isLoading } = useData();
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<'calls' | 'decisions' | 'name'>('calls');
 
-  const filteredSpeakers = mockSpeakers
-    .filter(speaker => 
+  const totalCalls = speakers.reduce((acc, s) => acc + s.stats.calls, 0);
+
+  const filteredSpeakers = speakers
+    .filter(speaker =>
       speaker.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       speaker.role.toLowerCase().includes(searchQuery.toLowerCase())
     )
@@ -24,6 +27,17 @@ export default function Speakers() {
       }
     });
 
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="w-12 h-12 text-ergo-orange animate-spin mx-auto mb-4" />
+          <p className="font-mono text-ergo-muted">Loading speakers...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       {/* Header */}
@@ -32,7 +46,7 @@ export default function Speakers() {
           Speaker Directory
         </h1>
         <p className="text-ergo-muted font-mono">
-          Meet the voices of the Ergo community across {mockSpeakers.reduce((acc, s) => acc + s.stats.calls, 0)}+ call appearances
+          Meet the voices of the Ergo community across {totalCalls}+ call appearances
         </p>
       </div>
 
@@ -136,16 +150,18 @@ export default function Speakers() {
               </div>
 
               {/* Top Topics */}
-              <div className="flex flex-wrap gap-2">
-                {speaker.top_topics.slice(0, 3).map(topic => (
-                  <span
-                    key={topic}
-                    className="text-xs font-mono px-2 py-1 bg-ergo-orange/10 text-ergo-orange rounded"
-                  >
-                    #{topic}
-                  </span>
-                ))}
-              </div>
+              {speaker.top_topics.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {speaker.top_topics.slice(0, 3).map(topic => (
+                    <span
+                      key={topic}
+                      className="text-xs font-mono px-2 py-1 bg-ergo-orange/10 text-ergo-orange rounded"
+                    >
+                      #{topic}
+                    </span>
+                  ))}
+                </div>
+              )}
             </Link>
           ))}
         </div>

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,0 +1,265 @@
+import type {
+  Index,
+  CallMeta,
+  QAData,
+  DecisionsData,
+  Topic,
+  Speaker,
+  AggregatedDecision,
+  AggregatedQA
+} from '../types';
+
+// Simple in-memory cache
+const cache = new Map<string, any>();
+
+async function fetchWithCache<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  if (cache.has(key)) {
+    return cache.get(key) as T;
+  }
+  const data = await fetcher();
+  cache.set(key, data);
+  return data;
+}
+
+// Fetch the main index
+export async function fetchIndex(): Promise<Index> {
+  return fetchWithCache('index', async () => {
+    const response = await fetch('/data/index.json');
+    if (!response.ok) throw new Error('Failed to fetch index');
+    return response.json();
+  });
+}
+
+// Fetch speakers list
+export async function fetchSpeakers(): Promise<Speaker[]> {
+  return fetchWithCache('speakers', async () => {
+    const response = await fetch('/data/speakers.json');
+    if (!response.ok) throw new Error('Failed to fetch speakers');
+    return response.json();
+  });
+}
+
+// Fetch topics list
+export async function fetchTopics(): Promise<Topic[]> {
+  return fetchWithCache('topics', async () => {
+    const response = await fetch('/data/topics.json');
+    if (!response.ok) throw new Error('Failed to fetch topics');
+    return response.json();
+  });
+}
+
+// Fetch individual call metadata
+export async function fetchCallMeta(filePrefix: string): Promise<CallMeta> {
+  const key = `call-meta-${filePrefix}`;
+  return fetchWithCache(key, async () => {
+    const response = await fetch(`/data/calls/${filePrefix}_meta.json`);
+    if (!response.ok) throw new Error(`Failed to fetch call meta: ${filePrefix}`);
+    return response.json();
+  });
+}
+
+// Fetch call summary markdown
+export async function fetchCallSummary(filePrefix: string): Promise<string> {
+  const key = `call-summary-${filePrefix}`;
+  return fetchWithCache(key, async () => {
+    const response = await fetch(`/data/calls/${filePrefix}_summary.md`);
+    if (!response.ok) throw new Error(`Failed to fetch call summary: ${filePrefix}`);
+    return response.text();
+  });
+}
+
+// Fetch call transcript
+export async function fetchCallTranscript(filePrefix: string): Promise<string> {
+  const key = `call-transcript-${filePrefix}`;
+  return fetchWithCache(key, async () => {
+    const response = await fetch(`/data/calls/${filePrefix}_transcript.txt`);
+    if (!response.ok) throw new Error(`Failed to fetch transcript: ${filePrefix}`);
+    return response.text();
+  });
+}
+
+// Fetch call Q&A
+export async function fetchCallQA(filePrefix: string): Promise<QAData> {
+  const key = `call-qa-${filePrefix}`;
+  return fetchWithCache(key, async () => {
+    const response = await fetch(`/data/calls/${filePrefix}_qa.json`);
+    if (!response.ok) throw new Error(`Failed to fetch call Q&A: ${filePrefix}`);
+    return response.json();
+  });
+}
+
+// Fetch call decisions
+export async function fetchCallDecisions(filePrefix: string): Promise<DecisionsData> {
+  const key = `call-decisions-${filePrefix}`;
+  return fetchWithCache(key, async () => {
+    const response = await fetch(`/data/calls/${filePrefix}_decisions.json`);
+    if (!response.ok) throw new Error(`Failed to fetch decisions: ${filePrefix}`);
+    return response.json();
+  });
+}
+
+// Fetch call marketing content
+export async function fetchCallMarketing(filePrefix: string): Promise<string> {
+  const key = `call-marketing-${filePrefix}`;
+  return fetchWithCache(key, async () => {
+    const response = await fetch(`/data/calls/${filePrefix}_marketing.md`);
+    if (!response.ok) throw new Error(`Failed to fetch marketing: ${filePrefix}`);
+    return response.text();
+  });
+}
+
+// Fetch call topics JSON
+export async function fetchCallTopics(filePrefix: string): Promise<string[]> {
+  const key = `call-topics-${filePrefix}`;
+  return fetchWithCache(key, async () => {
+    const response = await fetch(`/data/calls/${filePrefix}_topics.json`);
+    if (!response.ok) throw new Error(`Failed to fetch topics: ${filePrefix}`);
+    const data = await response.json();
+    // The topics file might be an array or object with topics property
+    return Array.isArray(data) ? data : (data.topics || []);
+  });
+}
+
+// Aggregate all Q&A from all calls
+export async function fetchAllQA(): Promise<AggregatedQA[]> {
+  const cacheKey = 'all-qa';
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey) as AggregatedQA[];
+  }
+
+  const index = await fetchIndex();
+  const allQA: AggregatedQA[] = [];
+
+  await Promise.all(
+    index.calls.map(async (call) => {
+      try {
+        const qaData = await fetchCallQA(call.file_prefix);
+        qaData.qa_pairs.forEach((qa) => {
+          allQA.push({
+            id: `${call.id}-qa-${qa.qa_id}`,
+            question: qa.question,
+            answer: qa.answer,
+            asker: qa.asker,
+            responder: qa.responder,
+            call_id: call.id,
+            call_title: call.title,
+            file_prefix: call.file_prefix,
+            date: call.date,
+            timestamp: qa.timestamp,
+            category: qa.category,
+            difficulty: qa.difficulty,
+          });
+        });
+      } catch (e) {
+        // Skip calls without Q&A
+      }
+    })
+  );
+
+  // Sort by date (newest first)
+  allQA.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  cache.set(cacheKey, allQA);
+  return allQA;
+}
+
+// Aggregate all decisions from all calls
+export async function fetchAllDecisions(): Promise<AggregatedDecision[]> {
+  const cacheKey = 'all-decisions';
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey) as AggregatedDecision[];
+  }
+
+  const index = await fetchIndex();
+  const allDecisions: AggregatedDecision[] = [];
+
+  await Promise.all(
+    index.calls.map(async (call) => {
+      try {
+        const decisionsData = await fetchCallDecisions(call.file_prefix);
+
+        // Add decisions
+        decisionsData.decisions?.forEach((d) => {
+          allDecisions.push({
+            id: `${call.id}-decision-${d.id}`,
+            type: 'decision',
+            title: d.decision,
+            content: d.quote || d.decision,
+            context: d.context,
+            speaker: d.speaker,
+            date: call.date,
+            call_id: call.id,
+            call_title: call.title,
+            file_prefix: call.file_prefix,
+            topic: d.topic,
+            significance: d.significance,
+            status: 'active',
+            quote: d.quote,
+          });
+        });
+
+        // Add commitments
+        decisionsData.commitments?.forEach((c) => {
+          allDecisions.push({
+            id: `${call.id}-commitment-${c.id}`,
+            type: 'commitment',
+            title: c.commitment,
+            content: c.quote || c.commitment,
+            speaker: c.owner,
+            owner: c.owner,
+            timeline: c.timeline,
+            date: call.date,
+            call_id: call.id,
+            call_title: call.title,
+            file_prefix: call.file_prefix,
+            topic: c.topic,
+            significance: 'minor',
+            status: 'pending',
+            quote: c.quote,
+          });
+        });
+
+        // Add open questions
+        decisionsData.open_questions?.forEach((q) => {
+          allDecisions.push({
+            id: `${call.id}-question-${q.id}`,
+            type: 'open_question',
+            title: q.question,
+            content: q.context,
+            context: q.context,
+            speaker: q.raised_by,
+            date: call.date,
+            call_id: call.id,
+            call_title: call.title,
+            file_prefix: call.file_prefix,
+            topic: q.topic,
+            significance: 'minor',
+            status: 'unresolved',
+          });
+        });
+      } catch (e) {
+        // Skip calls without decisions
+      }
+    })
+  );
+
+  // Sort by date (newest first)
+  allDecisions.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  cache.set(cacheKey, allDecisions);
+  return allDecisions;
+}
+
+// Find a call by ID
+export async function findCallById(id: string): Promise<{ call: CallMeta; filePrefix: string } | null> {
+  const index = await fetchIndex();
+  const callSummary = index.calls.find(c => c.id === id);
+
+  if (!callSummary) return null;
+
+  const callMeta = await fetchCallMeta(callSummary.file_prefix);
+  return { call: callMeta, filePrefix: callSummary.file_prefix };
+}
+
+// Clear cache (useful for development)
+export function clearCache(): void {
+  cache.clear();
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,48 @@
-export interface Call {
+// Index file schema
+export interface IndexStats {
+  total_calls: number;
+  total_qa: number;
+  total_decisions: number;
+  total_speakers: number;
+  total_topics: number;
+  total_hours: number;
+}
+
+export interface Index {
+  generated: string;
+  stats: IndexStats;
+  calls: CallSummary[];
+}
+
+// Call summary from index.json (lightweight)
+export interface CallSummary {
   id: string;
+  file_prefix: string;
+  date: string;
+  title: string;
+  type: 'community_chat' | 'ama' | 'tutorial' | 'special_event';
+  speakers: string[];
+  duration_minutes: number;
+  thumbnail: string;
+  stats: {
+    topics: number;
+    qa_pairs: number;
+    decisions: number;
+    commitments: number;
+  };
+  files: string[];
+}
+
+// Full call metadata from {prefix}_meta.json
+export interface CallMeta {
+  id: string;
+  file_prefix: string;
   date: string;
   title: string;
   type: 'community_chat' | 'ama' | 'tutorial' | 'special_event';
   duration_minutes: number;
   speakers: string[];
   topics: string[];
-  summary: string;
   stats: {
     topics: number;
     qa_pairs: number;
@@ -22,35 +58,74 @@ export interface Call {
   thumbnail: string;
 }
 
+// QA pair from {prefix}_qa.json
 export interface QAPair {
-  id: string;
+  qa_id: number;
+  timestamp: string;
   question: string;
   answer: string;
   asker?: string;
   responder: string;
-  call_id: string;
-  date: string;
-  timestamp?: string;
-  category: 'technical' | 'beginner' | 'governance' | 'projects' | 'general';
+  category: string;
   difficulty: 'beginner' | 'intermediate' | 'advanced';
+  related_terms?: string[];
 }
 
+export interface QAData {
+  call_date: string;
+  qa_pairs: QAPair[];
+}
+
+// Decision from {prefix}_decisions.json
 export interface Decision {
-  id: string;
-  type: 'decision' | 'commitment' | 'open_question' | 'reversal';
-  title: string;
-  content: string;
-  context?: string;
+  id: number;
+  timestamp: string;
+  decision: string;
   speaker: string;
-  date: string;
-  call_id: string;
+  context: string;
   topic: string;
   significance: 'major' | 'minor';
-  status: 'active' | 'superseded' | 'pending' | 'completed' | 'unresolved';
-  owner?: string;
-  timeline?: string;
+  quote?: string;
 }
 
+export interface Commitment {
+  id: number;
+  timestamp?: string;
+  commitment: string;
+  owner: string;
+  timeline: string;
+  topic: string;
+  quote?: string;
+}
+
+export interface OpenQuestion {
+  id: number;
+  timestamp?: string;
+  question: string;
+  context: string;
+  topic: string;
+  raised_by: string;
+}
+
+export interface KeyFact {
+  id: number;
+  timestamp: string;
+  fact: string;
+  speaker: string;
+  topic: string;
+}
+
+export interface DecisionsData {
+  call_date: string;
+  call_title?: string;
+  decisions: Decision[];
+  commitments: Commitment[];
+  open_questions: OpenQuestion[];
+  reversals_or_updates?: any[];
+  key_facts?: KeyFact[];
+}
+
+// Topic from topics.json
 export interface Topic {
   slug: string;
   name: string;
@@ -61,6 +136,7 @@ export interface Topic {
   related_topics: string[];
 }
 
+// Speaker from speakers.json
 export interface Speaker {
   name: string;
   role: string;
@@ -73,4 +149,40 @@ export interface Speaker {
     quotes: number;
   };
   top_topics: string[];
+}
+
+// Aggregated decision for UI display
+export interface AggregatedDecision {
+  id: string;
+  type: 'decision' | 'commitment' | 'open_question';
+  title: string;
+  content: string;
+  context?: string;
+  speaker: string;
+  date: string;
+  call_id: string;
+  call_title: string;
+  file_prefix: string;
+  topic: string;
+  significance: 'major' | 'minor';
+  status: 'active' | 'pending' | 'completed' | 'unresolved';
+  owner?: string;
+  timeline?: string;
+  quote?: string;
+}
+
+// Aggregated QA for UI display
+export interface AggregatedQA {
+  id: string;
+  question: string;
+  answer: string;
+  asker?: string;
+  responder: string;
+  call_id: string;
+  call_title: string;
+  file_prefix: string;
+  date: string;
+  timestamp?: string;
+  category: string;
+  difficulty: 'beginner' | 'intermediate' | 'advanced';
 }


### PR DESCRIPTION
- Add DataContext for app-wide data management
- Add dataService for fetching and caching JSON files
- Update all pages to use real data from public/data/
- Implement lazy loading for call detail tabs (summary, transcript, QA, decisions, marketing)
- Aggregate QA and decisions from all calls for FAQ and Decisions pages
- Add loading states with spinners throughout the app
- Update types to match the JSON schema from backend
- Update SearchContext to use DataContext for search indexing