### PR TITLE
Fix grid-bg overlay blocking clicks on titles

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -52,7 +52,7 @@ export default function Home() {
   return (
     <div className="relative">
       {/* Grid Background */}
-      <div className="absolute inset-0 grid-bg opacity-5"></div>
+      <div className="absolute inset-0 grid-bg opacity-5 pointer-events-none"></div>
 
       {/* Scan Line Effect */}
       <div className="scan-line"></div>


### PR DESCRIPTION
The absolute-positioned grid-bg div was covering the entire page without pointer-events-none, intercepting all click events on the Recent Calls and Recent Decisions sections below the hero.