### PR TITLE
Convert API function to JS to fix Vercel build

### DIFF
--- a/api/correction.js
+++ b/api/correction.js
@@ -1,9 +1,7 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
-
 const REPO_OWNER = 'cannonQ';
 const REPO_NAME = 'ergo-transcripts';
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }


### PR DESCRIPTION
The TypeScript version failed on Vercel due to @vercel/node and @types/node resolution issues. Plain JS eliminates the problem entirely - no type imports needed for a simple API handler.