### PR TITLE
Fix trailing comma in speakers.json breaking JSON parse

### DIFF
--- a/public/data/speakers.json
+++ b/public/data/speakers.json
@@ -46,8 +46,8 @@
       "quotes": 0
     },
     "top_topics": [
-      "USE Protocol",
-   ]
+      "USE Protocol"
+    ]
   },
   {
     "name": "Grayman",


### PR DESCRIPTION
A manual edit left a trailing comma in the top_topics array for one speaker, which is invalid JSON and caused the entire data load to fail.