### PR TITLE
Redesign landing page, 2-col calls grid, fix search

### DIFF
--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -29,9 +29,9 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
     if (!isInitialized) return null;
 
     const searchableData = [
-      ...calls.map(item => ({ type: 'call' as const, ...item })),
-      ...topics.map(item => ({ type: 'topic' as const, ...item })),
-      ...speakers.map(item => ({ type: 'speaker' as const, ...item })),
+      ...calls.map(item => ({ ...item, searchType: 'call' as const })),
+      ...topics.map(item => ({ ...item, searchType: 'topic' as const })),
+      ...speakers.map(item => ({ ...item, searchType: 'speaker' as const })),
     ];
 
     return new Fuse(searchableData, {
@@ -62,8 +62,7 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
 
     setResults(
       searchResults.map((result: any) => ({
-        type: result.item.type,
-        item: result.item,
+        ...result.item,
         score: result.score,
       }))
     );

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -161,7 +161,7 @@ export default function Calls() {
           </div>
 
           {/* Call Cards */}
-          <div className="space-y-6">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {filteredCalls.map(call => (
               <CallCard key={call.id} call={call} />
             ))}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowRight, TrendingUp, Activity, Loader2 } from 'lucide-react';
-import SearchBar from '../components/SearchBar';
 import CallCard from '../components/CallCard';
 import StatCard from '../components/StatCard';
 import TopicTag from '../components/TopicTag';
@@ -58,8 +57,8 @@ export default function Home() {
       <div className="scan-line"></div>
 
       {/* Hero Section */}
-      <section className="relative container mx-auto px-4 py-16">
-        <div className="text-center mb-12">
+      <section className="relative container mx-auto px-4 pt-16 pb-6">
+        <div className="text-center mb-8">
           <h1 className="text-5xl font-bold font-mono mb-4">
             <span className="text-gradient">ERGO KNOWLEDGE BASE</span>
           </h1>
@@ -69,23 +68,18 @@ export default function Home() {
           </p>
         </div>
 
-        {/* Stats Dashboard */}
-        <div className="bg-ergo-dark/80 backdrop-blur border border-ergo-orange/30 rounded-lg p-6 mb-12 glow-orange">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <StatCard label="CALLS INDEXED" value={stats?.total_calls || 0} />
-            <StatCard label="Q&A PAIRS" value={(stats?.total_qa || 0).toLocaleString()} />
-            <StatCard label="DECISIONS TRACKED" value={stats?.total_decisions || 0} />
-            <StatCard label="SPEAKERS" value={stats?.total_speakers || 0} />
-            <StatCard label="HOURS OF CONTENT" value={`${stats?.total_hours || 0}+`} />
-            <StatCard label="LAST SYNC" value="LIVE" />
-          </div>
-        </div>
-
-        {/* Search + Trending Topics Row */}
-        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
-          {/* Search Bar - 60% */}
-          <div className="lg:col-span-3">
-            <SearchBar className="w-full" autoFocus />
+        {/* Stats + Trending Topics Row */}
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+          {/* Stats - 60% */}
+          <div className="lg:col-span-3 bg-ergo-dark/80 backdrop-blur border border-ergo-orange/30 rounded-lg p-6 glow-orange">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <StatCard label="CALLS INDEXED" value={stats?.total_calls || 0} />
+              <StatCard label="Q&A PAIRS" value={(stats?.total_qa || 0).toLocaleString()} />
+              <StatCard label="DECISIONS TRACKED" value={stats?.total_decisions || 0} />
+              <StatCard label="SPEAKERS" value={stats?.total_speakers || 0} />
+              <StatCard label="HOURS OF CONTENT" value={`${stats?.total_hours || 0}+`} />
+              <StatCard label="LAST SYNC" value="LIVE" />
+            </div>
           </div>
 
           {/* Trending Topics - 40% */}

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -1,33 +1,41 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { Search, FileText, Mic, User, Hash, Gavel, ArrowLeft } from 'lucide-react';
+import { Search, Mic, User, Hash, ArrowLeft } from 'lucide-react';
 import { useSearch } from '../contexts/SearchContext';
 
 export default function SearchResults() {
   const [searchParams] = useSearchParams();
   const query = searchParams.get('q') || '';
-  const { results, isSearching } = useSearch();
+  const { results, isSearching, setQuery } = useSearch();
 
-  const getIcon = (type: string) => {
-    switch (type) {
+  // Sync URL query param to search context
+  useEffect(() => {
+    if (query) {
+      setQuery(query);
+    }
+  }, [query, setQuery]);
+
+  const getIcon = (searchType: string) => {
+    switch (searchType) {
       case 'call': return <Mic className="w-5 h-5 text-term-cyan" />;
-      case 'qa': return <FileText className="w-5 h-5 text-term-green" />;
-      case 'decision': return <Gavel className="w-5 h-5 text-term-amber" />;
       case 'topic': return <Hash className="w-5 h-5 text-ergo-orange" />;
-      case 'speaker': return <User className="w-5 h-5 text-term-magenta" />;
+      case 'speaker': return <User className="w-5 h-5 text-term-green" />;
       default: return <Search className="w-5 h-5 text-ergo-muted" />;
     }
   };
 
   const getLink = (result: any) => {
-    switch (result.type) {
+    switch (result.searchType) {
       case 'call': return `/calls/${result.id}`;
-      case 'qa': return `/faq#${result.id}`;
-      case 'decision': return `/decisions#${result.id}`;
       case 'topic': return `/topics/${result.slug || result.id}`;
       case 'speaker': return `/speakers/${encodeURIComponent(result.name || result.id)}`;
       default: return '#';
     }
+  };
+
+  const getLabel = (result: any) => {
+    if (result.searchType === 'call') return result.type?.replace(/_/g, ' ') || 'call';
+    return result.searchType;
   };
 
   return (
@@ -69,52 +77,41 @@ export default function SearchResults() {
         </div>
       )}
 
-      {/* Results */}
+      {/* Results - 4 column grid */}
       {!isSearching && query && results.length > 0 && (
-        <div className="space-y-4">
-          {results.map((result, index) => (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+          {results.map((result: any, index: number) => (
             <Link
-              key={`${result.type}-${result.id}-${index}`}
+              key={`${result.searchType}-${result.id || result.slug || result.name}-${index}`}
               to={getLink(result)}
-              className="block bg-ergo-dark border border-ergo-orange/20 rounded-lg p-6 hover:border-ergo-orange/50 transition-all"
+              className="block bg-ergo-dark border border-ergo-orange/20 rounded-lg p-4 hover:border-ergo-orange/50 transition-all"
             >
-              <div className="flex items-start gap-4">
-                <div className="p-2 bg-ergo-darker rounded">
-                  {getIcon(result.type)}
+              <div className="flex items-center gap-2 mb-2">
+                <div className="p-1.5 bg-ergo-darker rounded">
+                  {getIcon(result.searchType)}
                 </div>
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-xs font-mono text-ergo-muted uppercase">
-                      {result.type}
-                    </span>
-                    {result.date && (
-                      <span className="text-xs font-mono text-ergo-muted">
-                        • {new Date(result.date).toLocaleDateString()}
-                      </span>
-                    )}
-                  </div>
-                  <h3 className="font-mono text-lg font-semibold mb-2">
-                    {result.title || result.name || result.question}
-                  </h3>
-                  {(result.summary || result.content || result.answer || result.description) && (
-                    <p className="text-ergo-light/70 text-sm line-clamp-2">
-                      {result.summary || result.content || result.answer || result.description}
-                    </p>
-                  )}
-                  {result.topics && result.topics.length > 0 && (
-                    <div className="flex flex-wrap gap-2 mt-3">
-                      {result.topics.slice(0, 3).map((topic: string) => (
-                        <span
-                          key={topic}
-                          className="text-xs font-mono px-2 py-1 bg-ergo-orange/10 text-ergo-orange rounded"
-                        >
-                          #{topic}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                <span className="text-xs font-mono text-ergo-muted uppercase">
+                  {getLabel(result)}
+                </span>
+                {result.date && (
+                  <span className="text-xs font-mono text-ergo-muted ml-auto">
+                    {result.date}
+                  </span>
+                )}
               </div>
+              <h3 className="font-mono text-sm font-semibold text-ergo-orange mb-2 line-clamp-2">
+                {result.title || result.name || result.question}
+              </h3>
+              {(result.description || result.role || result.bio) && (
+                <p className="text-ergo-light/60 text-xs line-clamp-2">
+                  {result.description || result.role || result.bio}
+                </p>
+              )}
+              {result.speakers && result.speakers.length > 0 && (
+                <p className="text-xs font-mono text-ergo-muted mt-2 line-clamp-1">
+                  {result.speakers.filter(Boolean).join(', ')}
+                </p>
+              )}
             </Link>
           ))}
         </div>


### PR DESCRIPTION
Landing page:
- Removed search bar (use header search icon instead)
- Stats now 60/40 side-by-side with Trending Topics
- Reduced padding, Recent Calls sits right below

Calls page:
- Changed from single-column to 2-column grid

Search fixes:
- Fixed searchType collision (call data 'type' was overwriting search category 'type', so COMMUNITY_CHAT links went nowhere)
- Flatten search results so title/name/id are accessible
- Sync URL query param to search context on page load
- 4-column grid layout for search results
- Show call type label (community chat, ama) instead of raw type