### PR TITLE
Add "approved" label override for correction agent

### DIFF
--- a/.github/workflows/correction-agent.yml
+++ b/.github/workflows/correction-agent.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   process-correction:
-    if: github.event.label.name == 'correction'
+    if: >-
+      github.event.label.name == 'correction' ||
+      github.event.label.name == 'approved'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -32,3 +34,4 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
+          TRIGGER_LABEL: ${{ github.event.label.name }}


### PR DESCRIPTION
When Claude returns NEEDS_REVIEW or REJECT, the bot now tells maintainers to add the "approved" label to override. Adding "approved" re-triggers the workflow but skips Claude validation entirely, going straight to apply + PR creation.

Flow: correction label → Claude validates → NEEDS_REVIEW → maintainer adds "approved" label → agent re-runs, skips Claude, creates PR for final human merge review.