### PR TITLE
Fix JSON formatting in speakers.json

### DIFF
--- a/public/data/speakers.json
+++ b/public/data/speakers.json
@@ -136,7 +136,7 @@
     "top_topics": [
       "github-repository",
       "mewfinance",
-      "Mew Mart""Sigmanauts",
+      "Mew Mart", "Sigmanauts",
       "explorers"
     ],
     "accent": "Pakistani",
@@ -160,7 +160,7 @@
     "typical_topics": [
       "Palmyra",
       "development",
-      "business""zengate"
+      "business", "zengate"
     ],
     "stats": {
       "calls": 8,


### PR DESCRIPTION
Add missing commas between array values in top_topics and typical_topics:
- Line 139: "Mew Mart""Sigmanauts" -> "Mew Mart", "Sigmanauts"
- Line 163: "business""zengate" -> "business", "zengate"